### PR TITLE
ビットストリームに変換するオプションを追加

### DIFF
--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -23,6 +23,7 @@ esac
 avconv -i "${PLAYPATH}" \
        -t "${DURATION}" \
        -y \
+       -bsf:a aac_adtstoasc \
        -c copy "${TMPDIR}/${CHANNEL}_${DATE}.m4a"
 
 mv "${TMPDIR}/${CHANNEL}_${DATE}.m4a" "${OUTDIRLOCAL}/"


### PR DESCRIPTION
[このサイト](https://nyanshiba.hatenablog.com/entry/2018/02/03/071256)を参考にMPEG-2/4 AAC ADTSをMPEG-4 ASCビットストリームに変換するオプション`-bsf:a aac_adtstoasc`を付加する．