### PR TITLE
2026年5月時点でのURL変更とavconvをffmpegへ変更

### DIFF
--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# ===== 設定 =====
+# ===== settings =====
 DATE=$(date '+%Y%m%d_%H%M')
 XML_URL="https://www.nhk.or.jp/radio/config/config_web.xml"
 
-# ===== 引数チェック =====
+# ===== argument check =====
 if [ $# -ne 4 ]; then
   echo "usage: $0 channel(r1|r2|fm) duration(min) localdir remotedir"
   exit 1
@@ -15,7 +15,7 @@ DURATION=$(($2 * 60))
 OUTDIRLOCAL="$3"
 OUTDIR="$4"
 
-# ===== XML取得 =====
+# ===== get XML =====
 XML=$(curl -s "$XML_URL")
 
 extract_url() {
@@ -47,11 +47,11 @@ fi
 
 echo "M3U8: $PLAYPATH"
 
-# ===== 出力 =====
+# ===== output =====
 OUTFILE="${CHANNEL}_${DATE}.m4a"
 mkdir -p "$OUTDIRLOCAL"
 
-# ===== 録音（これが本命） =====
+# ===== recording =====
 ffmpeg -loglevel error \
   -headers "User-Agent: Mozilla/5.0" \
   -i "$PLAYPATH" \
@@ -61,13 +61,13 @@ ffmpeg -loglevel error \
   -y \
   "$OUTDIRLOCAL/$OUTFILE"
 
-# ===== 録音確認 =====
+# ===== confirm recording =====
 if [ ! -f "$OUTDIRLOCAL/$OUTFILE" ]; then
   echo "record failed"
   exit 1
 fi
 
-# ===== NAS転送 =====
+# ===== copy to remote directory =====
 cp "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/"
 
 echo "done: $OUTFILE"

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -69,6 +69,6 @@ if [ ! -f "$OUTDIRLOCAL/$OUTFILE" ]; then
 fi
 
 # ===== move to remote directory =====
-mv "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/"
+cp "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/" && rm "$OUTDIRLOCAL/$OUTFILE"
 
 echo "done: $OUTFILE"

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -6,7 +6,7 @@ XML_URL="https://www.nhk.or.jp/radio/config/config_web.xml"
 
 # ===== argument check =====
 if [ $# -ne 4 ]; then
-  echo "usage: $0 channel(r1|r2|fm) duration(min) localdir remotedir"
+  echo "usage: $0 channel(r1|fm) duration(min) localdir remotedir"
   exit 1
 fi
 
@@ -26,9 +26,10 @@ case "$CHANNEL" in
   r1)
     LINE=$(echo "$XML" | grep 'r1hls' | head -n1)
     ;;
-  r2)
-    LINE=$(echo "$XML" | grep 'r2hls' | head -n1)
-    ;;
+# r2 is stopped since 2026-03-30
+#  r2)
+#    LINE=$(echo "$XML" | grep 'r2hls' | head -n1)
+#    ;;
   fm)
     LINE=$(echo "$XML" | grep 'fmhls' | head -n1)
     ;;

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -67,7 +67,7 @@ if [ ! -f "$OUTDIRLOCAL/$OUTFILE" ]; then
   exit 1
 fi
 
-# ===== copy to remote directory =====
-cp "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/"
+# ===== move to remote directory =====
+mv "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/"
 
 echo "done: $OUTFILE"

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -1,30 +1,73 @@
 #!/bin/bash
 
-DATE=`date '+%Y%m%d_%H%M'`
-TMPDIR="/tmp"
+# ===== 設定 =====
+DATE=$(date '+%Y%m%d_%H%M')
+XML_URL="https://www.nhk.or.jp/radio/config/config_web.xml"
 
-if [ $# -eq 4 ]; then
-  CHANNEL="$1"
-  DURATION=`expr $2 \* 60`
-  OUTDIRLOCAL="$3"
-  OUTDIR="$4"
-else
-  echo "usage : $0 channel_name(r1|r2|fm) duration(minuites)"
+# ===== 引数チェック =====
+if [ $# -ne 4 ]; then
+  echo "usage: $0 channel(r1|r2|fm) duration(min) localdir remotedir"
   exit 1
 fi
 
-case $CHANNEL in
-    r1) PLAYPATH='https://nhkradioakr1-i.akamaihd.net/hls/live/511633/1-r1/1-r1-01.m3u8' ;;
-    r2) PLAYPATH='https://nhkradioakr2-i.akamaihd.net/hls/live/511929/1-r2/1-r2-01.m3u8' ;;
-    fm) PLAYPATH='https://nhkradioakfm-i.akamaihd.net/hls/live/512290/1-fm/1-fm-01.m3u8' ;;
-    *) exit 1 ;;
+CHANNEL="$1"
+DURATION=$(($2 * 60))
+OUTDIRLOCAL="$3"
+OUTDIR="$4"
+
+# ===== XML取得 =====
+XML=$(curl -s "$XML_URL")
+
+extract_url() {
+  echo "$1" | sed -E 's/.*CDATA\[([^]]+)\].*/\1/'
+}
+
+case "$CHANNEL" in
+  r1)
+    LINE=$(echo "$XML" | grep 'r1hls' | head -n1)
+    ;;
+  r2)
+    LINE=$(echo "$XML" | grep 'r2hls' | head -n1)
+    ;;
+  fm)
+    LINE=$(echo "$XML" | grep 'fmhls' | head -n1)
+    ;;
+  *)
+    echo "invalid channel"
+    exit 1
+    ;;
 esac
 
-avconv -i "${PLAYPATH}" \
-       -t "${DURATION}" \
-       -y \
-       -bsf:a aac_adtstoasc \
-       -c copy "${TMPDIR}/${CHANNEL}_${DATE}.m4a"
+PLAYPATH=$(extract_url "$LINE")
 
-mv "${TMPDIR}/${CHANNEL}_${DATE}.m4a" "${OUTDIRLOCAL}/"
-mv "${OUTDIRLOCAL}/${CHANNEL}_${DATE}.m4a" "${OUTDIR}/"
+if [ -z "$PLAYPATH" ]; then
+  echo "failed to get m3u8"
+  exit 1
+fi
+
+echo "M3U8: $PLAYPATH"
+
+# ===== 出力 =====
+OUTFILE="${CHANNEL}_${DATE}.m4a"
+mkdir -p "$OUTDIRLOCAL"
+
+# ===== 録音（これが本命） =====
+ffmpeg -loglevel error \
+  -headers "User-Agent: Mozilla/5.0" \
+  -i "$PLAYPATH" \
+  -t "$DURATION" \
+  -vn \
+  -acodec copy \
+  -y \
+  "$OUTDIRLOCAL/$OUTFILE"
+
+# ===== 録音確認 =====
+if [ ! -f "$OUTDIRLOCAL/$OUTFILE" ]; then
+  echo "record failed"
+  exit 1
+fi
+
+# ===== NAS転送 =====
+cp "$OUTDIRLOCAL/$OUTFILE" "$OUTDIR/"
+
+echo "done: $OUTFILE"

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -5,7 +5,7 @@ DATE=$(date '+%Y%m%d_%H%M')
 XML_URL="https://www.nhk.or.jp/radio/config/config_web.xml"
 
 # ===== area setting =====
-AREA="130"   # tokyo, if other area, please refer to https://www.nhk.or.jp/radio/config/config_web.xml
+AREA="tokyo"   # tokyo, if other area, please refer to https://www.nhk.or.jp/radio/config/config_web.xml
 
 # ===== argument check =====
 if [ $# -ne 4 ]; then
@@ -26,7 +26,12 @@ extract_url() {
 }
 
 # ===== extract area block =====
-AREA_BLOCK=$(echo "$XML" | awk "/<areacode>${AREA}<\/areacode>/,/<\/area>/")
+AREA_BLOCK=$(echo "$XML" | tr -d '\n' | sed 's#</area>#</area>\n#g' | grep "<area>${AREA}</area>")
+
+if [ -z "$AREA_BLOCK" ]; then
+  echo "failed to find area block (area=${AREA})"
+  exit 1
+fi
 
 # ===== select channel =====
 case "$CHANNEL" in

--- a/nhk-radio-recorder.sh
+++ b/nhk-radio-recorder.sh
@@ -4,6 +4,9 @@
 DATE=$(date '+%Y%m%d_%H%M')
 XML_URL="https://www.nhk.or.jp/radio/config/config_web.xml"
 
+# ===== area setting =====
+AREA="130"   # tokyo, if other area, please refer to https://www.nhk.or.jp/radio/config/config_web.xml
+
 # ===== argument check =====
 if [ $# -ne 4 ]; then
   echo "usage: $0 channel(r1|fm) duration(min) localdir remotedir"
@@ -22,16 +25,20 @@ extract_url() {
   echo "$1" | sed -E 's/.*CDATA\[([^]]+)\].*/\1/'
 }
 
+# ===== extract area block =====
+AREA_BLOCK=$(echo "$XML" | awk "/<areacode>${AREA}<\/areacode>/,/<\/area>/")
+
+# ===== select channel =====
 case "$CHANNEL" in
   r1)
-    LINE=$(echo "$XML" | grep 'r1hls' | head -n1)
+    LINE=$(echo "$AREA_BLOCK" | grep 'r1hls' | head -n1)
     ;;
 # r2 is stopped since 2026-03-30
 #  r2)
-#    LINE=$(echo "$XML" | grep 'r2hls' | head -n1)
+#    LINE=$(echo "$AREA_BLOCK" | grep 'r2hls' | head -n1)
 #    ;;
   fm)
-    LINE=$(echo "$XML" | grep 'fmhls' | head -n1)
+    LINE=$(echo "$AREA_BLOCK" | grep 'fmhls' | head -n1)
     ;;
   *)
     echo "invalid channel"
@@ -42,10 +49,11 @@ esac
 PLAYPATH=$(extract_url "$LINE")
 
 if [ -z "$PLAYPATH" ]; then
-  echo "failed to get m3u8"
+  echo "failed to get m3u8 (area=${AREA})"
   exit 1
 fi
 
+echo "AREA: $AREA"
 echo "M3U8: $PLAYPATH"
 
 # ===== output =====


### PR DESCRIPTION
1. URL自体の変更とURLから取得に変更
1. 第2放送`r2`は廃止されているためコメントアウト
1. `avconv`から`ffmpeg`へ変更
1. 処理エラーも考慮して`mv`から`cp`と`rm`に変更